### PR TITLE
Fix build issue with Android Studio and jackson jar missing file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,3 +22,10 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+

--- a/microsoft-azure-storage/build.gradle
+++ b/microsoft-azure-storage/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
-    compile files('com.fasterxml.jackson.core.jar')
+    compile 'com.fasterxml.jackson.core:jackson-core:2.8.5'
 }
 
 android {


### PR DESCRIPTION
Fix build issue with Android Studio: replaced missing com.fasterxml.jackson.core.jar file with a remote repository dependency.